### PR TITLE
Change UI elements' waitXXX methods to return a value.

### DIFF
--- a/java-framework/src/main/java/webui/automation/elements/Button.java
+++ b/java-framework/src/main/java/webui/automation/elements/Button.java
@@ -79,18 +79,20 @@ public class Button extends BaseElement {
 
     /**
      * Waits until this button becomes clickable, or until the specified timeout is reached.
+     * It returns the located clickable {@link WebElement}.
      *
      * @param  timeOutInSeconds  time out in seconds
+     * @return the located clickable {@link WebElement}
      * @throws TimeoutException if this button is still not clickable after the specified timeout is reached  
      */
-    public void waitUntilClickable(int timeOutInSeconds) {
+    public WebElement waitUntilClickable(int timeOutInSeconds) {
         if (getLocator() == null) {
             // TODO: Implement waiting for a WebElement to become clickable (rarely needed).
             throw new RuntimeException("This method is not yet implemented for a UI element that is tied to a particular WebElement.");
         } else {
             String timeOutMessage = "Timed out after " + timeOutInSeconds +
                     " seconds in waiting for " + this.getName() + " to become clickable.";
-            getBrowser().waitUntil(
+            return getBrowser().waitUntil(
                     ExpectedConditions.elementToBeClickable(getLocator()),
                     timeOutInSeconds, timeOutMessage);
         }

--- a/java-framework/src/main/java/webui/automation/factory/ElementFactory.java
+++ b/java-framework/src/main/java/webui/automation/factory/ElementFactory.java
@@ -40,6 +40,7 @@ public class ElementFactory {
     /**
      * Creates an object to represent a button on a web page.
      * @param  locator  The {@link By} locator for locating the button on a web page.
+     * @return the created {@link Button} element
      */
     public static Button createButton(By locator) {
         return new Button(locator);
@@ -48,6 +49,7 @@ public class ElementFactory {
     /**
      * Creates an object to represent a check box on a web page.
      * @param  locator  The {@link By} locator for locating the check box on a web page.
+     * @return the created {@link CheckBox} element
      */
     public static CheckBox createCheckBox(By locator) {
         return new CheckBox(locator);
@@ -56,8 +58,8 @@ public class ElementFactory {
     /**
      * Creates an object to represent a radio button on a web page.
      * @param  locator  The {@link By} locator for locating the radio button on a web page.
+     * @return the created {@link RadioButton} element
      */
-
     public static RadioButton createRadioButton(By locator) {
         return new RadioButton(locator);
     }
@@ -65,8 +67,8 @@ public class ElementFactory {
     /**
      * Creates an object to represent a table on a web page.
      * @param  locator  The {@link By} locator for locating the table on a web page.
+     * @return the created {@link Table} element
      */
-
     public static Table createTable(By locator) {
         return new Table(locator);
     }
@@ -74,17 +76,17 @@ public class ElementFactory {
     /**
      * Creates an object to represent a text on a web page.
      * @param  locator  The {@link By} locator for locating the text on a web page.
+     * @return the created {@link Text} element
      */
-
     public static Text createText(By locator) {
         return new Text(locator);
     }
 
     /**
-     * Creates an object to represent a text field on a web page.
+     * Creates an object to represent a text field (or called text box) on a web page.
      * @param  locator  The {@link By} locator for locating the text field on a web page.
+     * @return the created {@link TextField} element
      */
-
     public static TextField createTextField(By locator) {
         return new TextField(locator);
     }
@@ -92,8 +94,8 @@ public class ElementFactory {
     /**
      * Creates an object to represent a text link on a web page.
      * @param  locator  The {@link By} locator for locating the text link on a web page.
+     * @return the created {@link TextLink} element
      */
-
     public static TextLink createTextLink(By locator) {
         return new TextLink(locator);
     }

--- a/java-framework/src/main/java/webui/automation/framework/BaseElement.java
+++ b/java-framework/src/main/java/webui/automation/framework/BaseElement.java
@@ -291,37 +291,42 @@ public class BaseElement {
     }
 
     /**
-     * Waits until this UI element becomes present, or until the specified timeout is reached.
+     * Waits until this UI element becomes present (i.e., its HTML element is present in the DOM tree),
+     * or until the specified timeout is reached.
+     * It returns the located {@link WebElement}.
      *
      * @param  timeOutInSeconds  time out in seconds
+     * @return the located {@link WebElement}
      * @throws TimeoutException if this UI element is still not present after the specified timeout is reached  
      */
-    public void waitUntilPresent(int timeOutInSeconds) {
+    public WebElement waitUntilPresent(int timeOutInSeconds) {
         if (this.webElement != null) {
             // This UI element is already tied to a particular WebElement; there is no need to wait.
-            return;
+            return this.webElement;
         }
         String timeOutMessage = "Timed out after " + timeOutInSeconds +
             " seconds in waiting for " + this.getName() + " to become present.";
-        getBrowser().waitUntil(
+        return getBrowser().waitUntil(
             ExpectedConditions.presenceOfElementLocated(this.locator),
             timeOutInSeconds, timeOutMessage);
     }
 
     /**
-     * Waits until this UI element becomes present and visible, or until the specified timeout is reached.
+     * Waits until this UI element becomes visible, or until the specified timeout is reached.
+     * It returns the located {@link WebElement}.
      *
      * @param  timeOutInSeconds  time out in seconds
+     * @return the located {@link WebElement}
      * @throws TimeoutException if this UI element is still not visible after the specified timeout is reached  
      */
-    public void waitUntilVisible(int timeOutInSeconds) {
+    public WebElement waitUntilVisible(int timeOutInSeconds) {
         if (this.webElement != null) {
             // TODO: Implement waiting for a WebElement to become visible (rarely needed).
             throw new RuntimeException("This method is not yet implemented for a UI element that is tied to a particular WebElement.");
         }
         String timeOutMessage = "Timed out after " + timeOutInSeconds +
             " seconds in waiting for " + this.getName() + " to become visible.";
-        getBrowser().waitUntil(
+        return getBrowser().waitUntil(
             ExpectedConditions.visibilityOfElementLocated(this.locator),
             timeOutInSeconds, timeOutMessage);
     }
@@ -330,16 +335,17 @@ public class BaseElement {
      * Waits until this UI element becomes invisible, or until the specified timeout is reached.
      *
      * @param  timeOutInSeconds  time out in seconds
+     * @return the return value from {@link WebDriverWait#until}.
      * @throws TimeoutException if this UI element is still visible after the specified timeout is reached  
      */
-    public void waitUntilInvisible(int timeOutInSeconds) {
+    public Boolean waitUntilNotVisible(int timeOutInSeconds) {
         if (this.webElement != null) {
             // TODO: Implement waiting for a WebElement to become invisible (rarely needed).
             throw new RuntimeException("This method is not yet implemented for a UI element that is tied to a particular WebElement.");
         }
         String timeOutMessage = "Expecting " + this.getName() +
             " to disappear but it is still visible after " + timeOutInSeconds + " seconds.";
-        getBrowser().waitUntil(
+        return getBrowser().waitUntil(
             ExpectedConditions.invisibilityOfElementLocated(this.locator),
             timeOutInSeconds, timeOutMessage);
     }

--- a/java-framework/src/main/java/webui/automation/framework/BasePage.java
+++ b/java-framework/src/main/java/webui/automation/framework/BasePage.java
@@ -22,7 +22,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
  *   }
  * </pre> 
  */
-public class BasePage<T> {
+public class BasePage<T extends BasePage<T>> {
 
     private Browser browser = WebUI.getDefaultBrowser();
     private By locator;
@@ -85,11 +85,10 @@ public class BasePage<T> {
 
     /**
      * Returns whether this web page is available or not within the default page loading timeout,
-     * which is determined and can be configured by {@link WebUI#defaultPageLoadingTimeout}.
+     * which is specified and can be configured by {@link WebUI#defaultPageLoadingTimeout}.
      *
      * A page is considered available if the browser can use the locator of this page to locate a visible {@link WebElement}.
      *
-     * @param  timeOutInSeconds  timeout in seconds
      * @return <code>true</code> if this web page is available within the default page loading timeout;
      *         <code>false</code> otherwise
      */


### PR DESCRIPTION
Change the waitXXX methods to return a value (e.g., WebElement).
This usage is not as readable as the plain wait usage, but it enables
element codes to use the located WebElement without needing to locate
it again (or reimplement the waitXXX method).

Also add a restriction on the generic type T that can be passed into
the BasePage class.